### PR TITLE
Update skywalker_diff.py with logic from compare_mam4xx_mam4.py.

### DIFF
--- a/tools/skywalker_diff.py
+++ b/tools/skywalker_diff.py
@@ -10,7 +10,7 @@
 # will compare the two and produce difference norms for all of the 
 # output values.
 
-import os, sys, importlib, argparse
+import os, sys, importlib, argparse, itertools
 import numpy as np
 import numpy.linalg as lin
 
@@ -52,7 +52,7 @@ def check_output(f, key, abs_tol, rel_tol, vals1, vals2) :
     if isinstance(L1,(list,np.ndarray)) :
         i = 0
         for (l1,l2,linf, n1,n2,ninf) in zip(L1,L2,Linf, N1,N2,Ninf) :
-            if abs_tol < np.hstack((l1, l2, linf)).max() or rel_tol < np.hstack((l1/n1, l2/n2, linf/ninf)).max():
+            if abs_tol < np.hstack((l1, l2, linf)).max() or (0 < np.hstack((n1, n2, ninf)).max() and rel_tol < np.hstack((l1/n1, l2/n2, linf/ninf)).max()):
                 exceeds_tol = True
                 ind = "["+str(i)+"]"
                 f.write ("Norms for difference of output.{}{}: given absolute tolerance {} and relative tolerance {}\n".format(key, ind, abs_tol, rel_tol))
@@ -60,7 +60,7 @@ def check_output(f, key, abs_tol, rel_tol, vals1, vals2) :
                 f.write ("     Relative:  L1:{:12.6g}  L2:{:12.6g}  Linf:{:12.6g}\n".format(l1/n1, l2/n2, linf/ninf))
                 i = i + 1
     else :
-        if abs_tol < np.hstack((l1, l2, linf)).max() or rel_tol < np.hstack((l1/n1, l2/n2, linf/ninf)).max():
+        if abs_tol < np.hstack((L1, L2, Linf)).max() or (0 < np.hstack((N1, N2, Ninf)).max() and rel_tol < np.hstack((L1/N1, L2/N2, Linf/Ninf)).max()):
             exceeds_tol = True
             f.write ("Norms for difference of output.{}: given absolute tolerance {} and relative tolerance {}\n".format(key, abs_tol, rel_tol))
             f.write ("     Absolute:  L1:{:12.6g}  L2:{:12.6g}  Linf:{:12.6g}\n".format(L1, L2, Linf))
@@ -68,15 +68,28 @@ def check_output(f, key, abs_tol, rel_tol, vals1, vals2) :
     return exceeds_tol
 
 def intersect_vars(f, data1, data2, abs_tol, rel_tol, check_vals) :
+    pad_token = 0
     exceeds_tol = False
     vars1 = vars(data1)
     vars2 = vars(data2)
+
     keys1 = list(vars1)
     keys2 = list(vars2)
     keys = [key for key in keys1 if key in keys2]
     for key in keys :
-        vals1 = np.array(vars1[key])
-        vals2 = np.array(vars2[key])
+        o1 = vars1[key];
+        o2 = vars2[key];
+        # There is no requirement for the arrays in Skywalker to be regular. They could
+        # be ragged with each line a different length. But numpy arrays are made of
+        # regular lists. So find a command from Stackoverflow that will fill out
+        # irregular lists and padd with 0's.
+        if type(o1) is list and 0 < len(o1) and type(o1[0]) is list :
+            o1 = [list(i) for i in zip(*itertools.zip_longest(*o1, fillvalue=pad_token))]
+        if type(o2) is list and 0 < len(o2) and type(o2[0]) is list :
+            o2 = [list(i) for i in zip(*itertools.zip_longest(*o2, fillvalue=pad_token))]
+
+        vals1 = np.array(o1)
+        vals2 = np.array(o2)
         (vals1, vals2) = check_lens(f, key, vals1, vals2)
         # check_vals is either the check_input or check_output function
         exceeds_tol = exceeds_tol or check_vals(f, key, abs_tol, rel_tol, vals1, vals2)


### PR DESCRIPTION
The script compare_mam4xx_mam4.py will work on ragged arrays but in general skywalker_diff.py has more options.  Looking at the two, it seems we have created two scripts to do mostly the same thing. Once  skywalker_diff.py is updated and used everywhere compare_mam4xx_mam4.py can be deleted.